### PR TITLE
Added sample prometheus configuration for decisionengine metrics 

### DIFF
--- a/de_monitoring/prometheus/prometheus.yml
+++ b/de_monitoring/prometheus/prometheus.yml
@@ -9,7 +9,6 @@ scrape_configs:
   - job_name: 'prometheus'
     # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
-    metrics_path: '/prometheus/metrics'
     # scheme defaults to 'http'.
     static_configs:
       - targets: ['localhost:9090']

--- a/de_monitoring/prometheus/prometheus.yml
+++ b/de_monitoring/prometheus/prometheus.yml
@@ -1,0 +1,21 @@
+# Sample global config
+global:
+  scrape_interval:     60s
+  evaluation_interval: 10s
+  scrape_timeout:      10s
+
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+    metrics_path: '/prometheus/metrics'
+    # scheme defaults to 'http'.
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'decisionengine'
+    scrape_interval: 1m
+    static_configs:
+      - targets: ['<de_host>:8000']
+  
+


### PR DESCRIPTION
This PR adds a sample configuration to be deployed (or added) to the prometheus server that aims to scrape metrics from the HEPCloud Decision Engine.